### PR TITLE
Added support for spacing between stars

### DIFF
--- a/Classes/AMRatingControl.h
+++ b/Classes/AMRatingControl.h
@@ -19,8 +19,9 @@
 #pragma mark - Getters and Setters
 
 @property (nonatomic, assign) NSInteger rating;
-@property (nonatomic, readwrite) NSUInteger fontSize;
+@property (nonatomic, readwrite) NSUInteger starFontSize;
 @property (nonatomic, readwrite) NSUInteger starWidthAndHeight;
+@property (nonatomic, readwrite) NSUInteger starSpacing;
 
 /**************************************************************************************************/
 #pragma mark - Birth & Death

--- a/Classes/AMRatingControl.m
+++ b/Classes/AMRatingControl.m
@@ -10,6 +10,7 @@
 // Constants :
 static const CGFloat kFontSize = 20;
 static const NSInteger kStarWidthAndHeight = 20;
+static const NSInteger kStarSpacing = 0;
 
 static const NSString *kDefaultEmptyChar = @"☆";
 static const NSString *kDefaultSolidChar = @"★";
@@ -24,7 +25,7 @@ static const NSString *kDefaultSolidChar = @"★";
             solidColor:(UIColor *)solidColor
           andMaxRating:(NSInteger)maxRating;
 
-
+- (void)adjustFrame;
 - (void)handleTouch:(UITouch *)touch;
 
 @end
@@ -37,8 +38,9 @@ static const NSString *kDefaultSolidChar = @"★";
 #pragma mark - Getters & Setters
 
 @synthesize rating = _rating;
-@synthesize fontSize = _fontSize;
+@synthesize starFontSize = _starFontSize;
 @synthesize starWidthAndHeight = _starWidthAndHeight;
+@synthesize starSpacing = _starSpacing;
 
 - (void)setRating:(NSInteger)rating
 {
@@ -50,8 +52,15 @@ static const NSString *kDefaultSolidChar = @"★";
 - (void)setStarWidthAndHeight:(NSUInteger)starWidthAndHeight
 {
     _starWidthAndHeight = starWidthAndHeight;
-    CGRect newFrame = CGRectMake(self.frame.origin.x, self.frame.origin.y, _maxRating *starWidthAndHeight, starWidthAndHeight);
-    self.frame = newFrame;
+    [self adjustFrame];
+    [self setNeedsDisplay];
+}
+
+- (void)setStarSpacing:(NSUInteger)starSpacing
+{
+    _starSpacing = starSpacing;
+    [self adjustFrame];
+    [self setNeedsDisplay];
 }
 
 /**************************************************************************************************/
@@ -118,10 +127,10 @@ static const NSString *kDefaultSolidChar = @"★";
 		else
         {
             CGContextSetFillColorWithColor(UIGraphicsGetCurrentContext(), _solidColor.CGColor);
-            [kDefaultSolidChar drawAtPoint:currPoint withFont:[UIFont boldSystemFontOfSize:_fontSize]];
+            [kDefaultSolidChar drawAtPoint:currPoint withFont:[UIFont boldSystemFontOfSize:_starFontSize]];
         }
 			
-		currPoint.x += _starWidthAndHeight;
+		currPoint.x += (_starWidthAndHeight + _starSpacing);
 	}
 	
 	NSInteger remaining = _maxRating - _rating;
@@ -135,9 +144,9 @@ static const NSString *kDefaultSolidChar = @"★";
 		else
         {
             CGContextSetFillColorWithColor(UIGraphicsGetCurrentContext(), _emptyColor.CGColor);
-			[kDefaultEmptyChar drawAtPoint:currPoint withFont:[UIFont boldSystemFontOfSize:_fontSize]];
+			[kDefaultEmptyChar drawAtPoint:currPoint withFont:[UIFont boldSystemFontOfSize:_starFontSize]];
         }
-		currPoint.x += _starWidthAndHeight;
+		currPoint.x += (_starWidthAndHeight + _starSpacing);
 	}
 }
 
@@ -187,17 +196,24 @@ static const NSString *kDefaultSolidChar = @"★";
         _emptyColor = emptyColor;
         _solidColor = solidColor;
         _maxRating = maxRating;
-        _fontSize = kFontSize;
+        _starFontSize = kFontSize;
         _starWidthAndHeight = kStarWidthAndHeight;
+        _starSpacing = kStarSpacing;
 	}
 	
 	return self;
 }
 
+- (void)adjustFrame
+{
+    CGRect newFrame = CGRectMake(self.frame.origin.x, self.frame.origin.y, _maxRating * _starWidthAndHeight + (_maxRating - 1) * _starSpacing, _starWidthAndHeight);
+    self.frame = newFrame;
+}
+
 - (void)handleTouch:(UITouch *)touch
 {
     CGFloat width = self.frame.size.width;
-	CGRect section = CGRectMake(0, 0, (width / _maxRating), self.frame.size.height);
+	CGRect section = CGRectMake(0, 0, _starWidthAndHeight, self.frame.size.height);
 	
 	CGPoint touchLocation = [touch locationInView:self];
 	
@@ -221,7 +237,7 @@ static const NSString *kDefaultSolidChar = @"★";
 	{
 		for (int i = 0 ; i < _maxRating ; i++)
 		{
-			if ((touchLocation.x > section.origin.x) && (touchLocation.x < (section.origin.x + section.size.width)))
+			if ((touchLocation.x > section.origin.x) && (touchLocation.x < (section.origin.x + _starWidthAndHeight)))
 			{
 				if (_rating != (i+1))
 				{
@@ -230,7 +246,7 @@ static const NSString *kDefaultSolidChar = @"★";
 				}
 				break;
 			}
-			section.origin.x += section.size.width;
+			section.origin.x += (_starWidthAndHeight + _starSpacing);
 		}
 	}
 	[self setNeedsDisplay];

--- a/Demo/Controller/AMRatingControlViewController.m
+++ b/Demo/Controller/AMRatingControlViewController.m
@@ -23,11 +23,12 @@
     // Create a simple instance, initing with :
     // - a CGPoint (the position in your view from which it will be drawn)
     // - and max rating
-	AMRatingControl *simpleRatingControl = [[AMRatingControl alloc] initWithLocation:CGPointMake(110, 50)
+	AMRatingControl *simpleRatingControl = [[AMRatingControl alloc] initWithLocation:CGPointMake(90, 50)
                                                                   andMaxRating:5];
     
     // Customize the current rating if needed
     [simpleRatingControl setRating:3];
+    [simpleRatingControl setStarSpacing:10];
     
     // Listen to control events
 	[simpleRatingControl addTarget:self action:@selector(updateRating:) forControlEvents:UIControlEventEditingChanged];

--- a/Demo/Controller/AMRatingControlViewController.xib
+++ b/Demo/Controller/AMRatingControlViewController.xib
@@ -2,13 +2,13 @@
 <archive type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="7.10">
 	<data>
 		<int key="IBDocument.SystemTarget">784</int>
-		<string key="IBDocument.SystemVersion">11G56</string>
-		<string key="IBDocument.InterfaceBuilderVersion">2840</string>
-		<string key="IBDocument.AppKitVersion">1138.51</string>
-		<string key="IBDocument.HIToolboxVersion">569.00</string>
+		<string key="IBDocument.SystemVersion">12D78</string>
+		<string key="IBDocument.InterfaceBuilderVersion">3084</string>
+		<string key="IBDocument.AppKitVersion">1187.37</string>
+		<string key="IBDocument.HIToolboxVersion">626.00</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-			<string key="NS.object.0">1926</string>
+			<string key="NS.object.0">2083</string>
 		</object>
 		<object class="NSArray" key="IBDocument.IntegratedClassDependencies">
 			<bool key="EncodedWithXMLCoder">YES</bool>
@@ -150,13 +150,13 @@
 						<int key="IBUIContentMode">7</int>
 						<bool key="IBUIUserInteractionEnabled">NO</bool>
 						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-						<string key="IBUIText">Simple Rating Control</string>
+						<string key="IBUIText">Simple Rating Control (10px Space)</string>
 						<reference key="IBUITextColor" ref="605116027"/>
 						<nil key="IBUIHighlightedColor"/>
 						<int key="IBUIBaselineAdjustment">0</int>
+						<float key="IBUIMinimumScaleFactor">0.5</float>
 						<reference key="IBUIFontDescription" ref="107571223"/>
 						<reference key="IBUIFont" ref="686500288"/>
-						<bool key="IBUIAdjustsFontSizeToFit">NO</bool>
 					</object>
 					<object class="IBUILabel" id="849198912">
 						<reference key="NSNextResponder" ref="774585933"/>
@@ -423,6 +423,6 @@
 		</object>
 		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
 		<int key="IBDocument.defaultPropertyAccessControl">3</int>
-		<string key="IBCocoaTouchPluginVersion">1926</string>
+		<string key="IBCocoaTouchPluginVersion">2083</string>
 	</data>
 </archive>


### PR DESCRIPTION
Added new starSpacing property and corresponding constant; adjusted drawing and handling touches to spacing; calling setNeedsDisplay also on changes of startWitdthAndHeight and starSpacing; renamed fontSize to more descriptive starFontSize; extended the example to make use of the new spacing feature.
