### PR TITLE
Added support for Auto Layout and creation from xibs

### DIFF
--- a/Classes/AMRatingControl.h
+++ b/Classes/AMRatingControl.h
@@ -11,16 +11,12 @@ typedef void (^EditingDidEndBlock)(NSUInteger rating);
 
 
 @interface AMRatingControl : UIControl
-{
-	UIImage *_emptyImage, *_solidImage;
-    UIColor *_emptyColor, *_solidColor;
-    NSInteger _maxRating;
-}
 
 
 /**************************************************************************************************/
 #pragma mark - Getters and Setters
 
+@property (nonatomic, assign) NSInteger maxRating;
 @property (nonatomic, assign) NSInteger rating;
 @property (nonatomic, readwrite) NSUInteger starFontSize;
 @property (nonatomic, readwrite) NSUInteger starWidthAndHeight;


### PR DESCRIPTION
I've added support for Auto Layout by implementing `-instrinsicContentSize` on the control and slightly edited `-adjustFrame` to use AutoLayout when it's enabled.

I've also moved the initialization stuff from `-initWithLocation:emptyImage:solidImage:emptyColor:solidColor:andMaxRating:` into a common initialization method.

Calling this new initialization method from `-initWithCoder:` enables to create a rating control in a xib file.
As it's not possible to give a value to maxRating in the xib, I've added a public property `maxRating` public so it can be changed later (in `viewDidLoad` for example).
